### PR TITLE
chore: 更新子模块仓库地址, 避免匿名用户拉取失败

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lua"]
 	path = lua
-	url = git@github.com:dzpao/lua-mud-robots
+	url = https://github.com/dzpao/lua-mud-robots.git


### PR DESCRIPTION
当用户没有配置git公钥登录的时候，更新子模块会报权限错误而失败，更新成这种http格式的地址后就正常了